### PR TITLE
Fix AUTOINCREMENT

### DIFF
--- a/src/main/java/liquibase/ext/snowflake/database/SnowflakeDatabase.java
+++ b/src/main/java/liquibase/ext/snowflake/database/SnowflakeDatabase.java
@@ -27,6 +27,8 @@ public class SnowflakeDatabase extends AbstractJdbcDatabase {
         super.unmodifiableDataTypes.addAll(Arrays.asList("integer", "bool", "boolean", "int4", "int8", "float4", "float8", "numeric", "bigserial", "serial", "bytea", "timestamptz"));
         super.unquotedObjectsAreUppercased = false;
         super.addReservedWords(getDefaultReservedWords());
+        super.defaultAutoIncrementStartWith = BigInteger.ONE;
+        super.defaultAutoIncrementBy = BigInteger.ONE;
     }
 
     @Override
@@ -137,13 +139,6 @@ public class SnowflakeDatabase extends AbstractJdbcDatabase {
         return false;
     }
 
-    public String getAutoIncrementClause(BigInteger startWith, BigInteger incrementBy) {
-        if (startWith != null && incrementBy != null) {
-            return " AUTOINCREMENT(" + startWith + "," + incrementBy + ") ";
-        }
-        return " AUTOINCREMENT ";
-    }
-
     @Override
     public boolean supportsAutoIncrement() {
         return true;
@@ -151,7 +146,15 @@ public class SnowflakeDatabase extends AbstractJdbcDatabase {
 
     @Override
     public String getAutoIncrementClause() {
-        return "";
+        return "AUTOINCREMENT";
+    }
+
+    protected String getAutoIncrementStartWithClause() {
+        return "%d";
+    }
+
+    protected String getAutoIncrementByClause() {
+        return "%d";
     }
 
     @Override

--- a/src/test/java/liquibase/ext/snowflake/database/SnowflakeDatabaseTest.java
+++ b/src/test/java/liquibase/ext/snowflake/database/SnowflakeDatabaseTest.java
@@ -1,5 +1,7 @@
 package liquibase.ext.snowflake.database;
 
+import liquibase.database.AbstractJdbcDatabase;
+import liquibase.database.Database;
 import liquibase.ext.snowflake.helpers.SetUtils;
 import liquibase.CatalogAndSchema;
 import liquibase.database.jvm.JdbcConnection;
@@ -137,9 +139,13 @@ public class SnowflakeDatabaseTest {
 
     @Test
     public void testGetAutoIncrementClause() {
-        assertEquals("", database.getAutoIncrementClause());
-        assertEquals(" AUTOINCREMENT ", database.getAutoIncrementClause(null, null));
-        assertEquals(" AUTOINCREMENT(1,1) ", database.getAutoIncrementClause(new BigInteger("1"), new BigInteger("1")));
+        assertEquals("AUTOINCREMENT", database.getAutoIncrementClause());
+        assertEquals("AUTOINCREMENT (1, 1)", database.getAutoIncrementClause(null, null, null, null));
+        assertEquals("AUTOINCREMENT (1, 1)", database.getAutoIncrementClause(new BigInteger("1"), new BigInteger("1"), null, null));
+        assertEquals("AUTOINCREMENT (7, 1)", database.getAutoIncrementClause(new BigInteger("7"), new BigInteger("1"), null, null));
+        assertEquals("AUTOINCREMENT (1, 7)", database.getAutoIncrementClause(new BigInteger("1"), new BigInteger("7"), null, null));
+        assertEquals("AUTOINCREMENT (7, 1)", database.getAutoIncrementClause(new BigInteger("7"), null, null, null));
+        assertEquals("AUTOINCREMENT (1, 7)", database.getAutoIncrementClause(null, new BigInteger("7"), null, null));
     }
 
     @Test


### PR DESCRIPTION
AUTOINCREMENT was not working with the previous implementation, since the actual AUTOINCREMENT/IDENTITY keyword was missing.

Based on other examples, this should usually be provided by AbstractJdbcDatabase#getAutoIncrementClause().

On the other hand, the SnowflakeDatabase#getAutoIncrementClause(BigInteger,BigInteger) method is as far as I can tell irrelevant, since it's not exposed or used by AbstractJdbcDatabase or the Database interface.

The updated auto-increment code has been tested against a live Snowflake instance to create tables with auto-increment enabled.